### PR TITLE
Make 'More...' link on home page work by removing class tag and also using named route

### DIFF
--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -6,7 +6,7 @@
       %span Voting redefined.
     %h4
       Browse proposals, support one or branch your own. Participate in real decisions.
-      = link_to 'More...', '/about', class: 'more'
+      = link_to 'More...', about_path
   
   - if @sortTitle != '' or @searched != '' or user_signed_in?
     #searchResults


### PR DESCRIPTION
Clicking on the 'More...' link on the home page doesn't actually seem to issue a get request for '/about'. I rewrote the view to use a named route, which seems like good housekeeping, and I also found that removing the :class html option makes the link work.
