### PR TITLE
Proposals  belong hubs Schema change

### DIFF
--- a/app/models/hub.rb
+++ b/app/models/hub.rb
@@ -16,7 +16,7 @@ class Hub < ActiveRecord::Base
 
   # Associations
   has_many :votes
-  has_many :proposals, through: :votes
+  has_many :proposals  # replaces # has_many :proposals, through: :votes
 
   # Named Scopes
   scope :by_group_name, lambda { |group_name| where("LOWER(group_name) = ?", group_name.downcase) }

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -17,8 +17,8 @@ class Proposal < ActiveRecord::Base
 
   # Associations
   belongs_to :user
+  belongs_to :hub    # replaces #  has_many :hubs, through: :votes
   has_many :votes, inverse_of: :proposal
-  has_many :hubs, through: :votes
 
   accepts_nested_attributes_for :votes, reject_if: :all_blank
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -19,7 +19,7 @@ class Vote < ActiveRecord::Base
   # Associations
   belongs_to :proposal, counter_cache: true, inverse_of: :votes
   belongs_to :user
-  belongs_to :hub
+  belongs_to :hub, ThroughAssociation: :proposal   # Replaces # belongs_to :hub
 
   # Validations
   validates :comment, :user, :proposal, presence: true

--- a/db/migrate/20130122204630_add_hub_id_to_proposals.rb
+++ b/db/migrate/20130122204630_add_hub_id_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddHubIdToProposals < ActiveRecord::Migration
+  def change
+    add_column :proposals, :hub_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130118085812) do
+ActiveRecord::Schema.define(:version => 20130122204630) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(:version => 20130118085812) do
     t.integer  "votes_count", :default => 0
     t.string   "ancestry"
     t.integer  "created_by"
+    t.integer  "hub_id"
   end
 
   add_index "proposals", ["ancestry"], :name => "index_positions_on_ancestry"


### PR DESCRIPTION
Not sure this is ready for merging, as it contains only the migration and model changes, no code adjustments.
- While the hub_id is present on Proposals, for testing hub_id has not yet been removed from Votes.
- If someone wants to begin working on the code adjustments please feel free to merge or pull the branch, and I will begin working on the seed file to populate data for testing.

![Proposal belongs to Hub Schema](https://f.cloud.github.com/assets/2165336/88154/6ee2df64-64e0-11e2-97e2-3991a4621f4a.png)
