### PR TITLE
ensure error message shown on location-only searches

### DIFF
--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -84,7 +84,7 @@ window.app = {};
   // --
 
   var createAlert = function (msg, style) {
-    $('.content_page').prepend('<div class="alert alert-' + style + ' no-gutter"><a href="#" class="close" data-dismiss="alert">&times;</a>' + msg + '</div>');
+    $('#main').find('.content .row').first().prepend('<div class="alert alert-' + style + '"><a href="#" class="close" data-dismiss="alert">&times;</a>' + msg + '</div>');
   }
 
   var setPageHeight = function() {

--- a/app/assets/stylesheets/partials/_styles.css.scss
+++ b/app/assets/stylesheets/partials/_styles.css.scss
@@ -33,7 +33,7 @@ footer {
   .control-group, .supporting-args { margin-bottom: 10px; }
 }
 
-.alert { width: 810px; margin-left: 20px; }
+.alert { width: 810px; margin-left: 60px; }
 .no-gutter { margin-left: 0; }
 // end Structural
 


### PR DESCRIPTION
Fixes https://trello.com/card/on-the-home-page-the-search-form-does-not-submit-when-only-selecting-a-location-filter-and-hitting-search-it-does-not-give-any-message-as-well/50db1f1f9aaccd882d00272c/52
