### PR TITLE
fix user name display in proposals table

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -182,6 +182,10 @@ private
 
         @proposals = Proposal.roots
       end
+    elsif params[:user_id]
+      session[:search_hub] = nil      
+      @proposals = User.where({id: params[:user_id]}).first.proposals.roots
+      @sortTitle = @proposals.first.user.username + "'s "
     elsif user_signed_in?
       session[:search_hub] = nil      
       @proposals = current_user.proposals.roots


### PR DESCRIPTION
Implements https://trello.com/card/clicking-a-username-in-a-proposal-shows-the-correct-proposals-list-but-not-the-user-s-name-in-the-table-title-says-my-proposals/50db1f1f9aaccd882d00272c/110
