### PR TITLE
Alert refinements, new modal logic, set up sign-in interception

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_controller.coffee
+++ b/app/assets/javascripts/angular/controllers/dashboard_controller.coffee
@@ -1,4 +1,4 @@
-DashboardCtrl = ($scope, $route, $location, $dialog, SessionSettings, CurrentHubLoader, VotingService) ->
+DashboardCtrl = ($scope, $route, $location, SessionSettings, CurrentHubLoader, VotingService) ->
 
   SessionSettings.routeParams = $route.current.params
   if $route.current.params.hub?
@@ -59,5 +59,5 @@ DashboardCtrl = ($scope, $route, $location, $dialog, SessionSettings, CurrentHub
     angular.element('.select2-drop-active').select2 'close'
     angular.element('#newProposalHub').select2('data',null)
 
-DashboardCtrl.$inject = [ '$scope', '$route', '$location', '$dialog', 'SessionSettings', 'CurrentHubLoader', 'VotingService' ]
+DashboardCtrl.$inject = [ '$scope', '$route', '$location', 'SessionSettings', 'CurrentHubLoader', 'VotingService' ]
 App.controller 'DashboardCtrl', DashboardCtrl

--- a/app/assets/javascripts/angular/controllers/root_controller.coffee
+++ b/app/assets/javascripts/angular/controllers/root_controller.coffee
@@ -1,4 +1,4 @@
-RootCtrl = ($scope, AlertService, $location, $dialog, $modal, SessionService, SessionSettings, CurrentUserLoader) ->
+RootCtrl = ($scope, AlertService, $location, $dialog, SessionService, SessionSettings, CurrentUserLoader) ->
   $scope.alertService = AlertService
   $scope.session = SessionService.userSession
   $scope.sessionSettings = SessionSettings
@@ -6,45 +6,36 @@ RootCtrl = ($scope, AlertService, $location, $dialog, $modal, SessionService, Se
     $scope.currentUser = current_user
     $location.path('/proposals').search('filter', 'my_votes') if $scope.currentUser.username? and $location.path() == '/'
 
-#    console.log $scope.currentUser
-#    console.log $scope.currentUser.is_admin?
-#  if $scope.currentUser.is_admin?.to_text is 'true'
-#    console.log "console.log $scope.currentUser.is_admin?" + $scope.currentUser.is_admin?
-
   $scope.$on "event:loginRequired", ->
     $scope.signInModal()
 
   $scope.signInModal = ->
     if SessionSettings.openModals.signIn is false
-      $scope.opts =
+      opts =
         resolve:
-          parentScope: ->
+          $scope: ->
             $scope
-      d = $dialog.dialog($scope.opts)
+      d = $dialog.dialog(opts)
       SessionSettings.openModals.signIn = true
       d.open('/assets/shared/_sign_in_modal.html.haml', 'SessionCtrl').then (result) ->
         SessionSettings.openModals.signIn = d.isOpen()
 
-
-#  $scope.signInModal = ->
-#    $modal
-#      template: '/assets/shared/_sign_in_modal.html.haml'
-#      show: true
-#      backdrop: 'static'
-#      scope: $scope
-
   $scope.registerModal = ->
-    $modal
-      template: '/assets/shared/_registration_modal.html.haml'
-      show: true
-      backdrop: 'static'
-      scope: $scope
+    if SessionSettings.openModals.register is false
+      opts =
+        resolve:
+          $scope: ->
+            $scope
+      d = $dialog.dialog(opts)
+      SessionSettings.openModals.register = true
+      d.open('/assets/shared/_registration_modal.html.haml', 'RegistrationCtrl').then (result) ->
+        SessionSettings.openModals.register = d.isOpen()
 
   $scope.signOut = ->
     $scope.session.$destroy()
     $scope.currentUser = {}
     $location.path('/').search('')
-    AlertService.setInfo 'You are signed out.', $scope
+    AlertService.setInfo 'You are signed out.', $scope, 'main'
 
   $scope.updateUserSession = ->
     CurrentUserLoader().then (current_user) ->
@@ -64,5 +55,5 @@ RootCtrl = ($scope, AlertService, $location, $dialog, $modal, SessionService, Se
       if response.success == false
         AlertService.setCtlResult 'Sorry, we were not able to sign you in using {{ provider }}.', $scope
 
-RootCtrl.$inject = ['$scope', 'AlertService', '$location', '$dialog', '$modal', 'SessionService', 'SessionSettings', 'CurrentUserLoader' ]
+RootCtrl.$inject = ['$scope', 'AlertService', '$location', '$dialog', 'SessionService', 'SessionSettings', 'CurrentUserLoader' ]
 App.controller 'RootCtrl', RootCtrl

--- a/app/assets/javascripts/angular/controllers/sessions_controller.coffee
+++ b/app/assets/javascripts/angular/controllers/sessions_controller.coffee
@@ -1,4 +1,4 @@
-SessionCtrl = ($scope, parentScope, $cookieStore, $location, dialog, SessionService, AlertService) ->
+SessionCtrl = ($scope, $cookieStore, $location, SessionService, AlertService, dialog) ->
   $scope.alertService = AlertService
   $scope.session = SessionService.userSession
 
@@ -8,18 +8,18 @@ SessionCtrl = ($scope, parentScope, $cookieStore, $location, dialog, SessionServ
       $scope.session.$save().success (response, status, headers, config) ->
         if response.success == true
           dialog.close(response)
-          parentScope.updateUserSession()
+          $scope.updateUserSession()
           $location.path('/proposals').search('filter', 'my_votes')
-          AlertService.setInfo 'You are signed in!', $scope
+          AlertService.setInfo 'You are signed in!', $scope, 'main'
           $cookieStore.put "spokenvote_email", $scope.session.email if $scope.session.remember_me == true
         #        $cookieStore.put "_spokenvote_session", response   #let Angular set the cookie in the future?
         if response.success == false
-          AlertService.setCtlResult 'Sorry, we were not able to sign you in with the supplied email and password.', $scope
+          AlertService.setCtlResult 'Sorry, we were not able to sign you in with the supplied email and password.', $scope, 'modal'
 
   $scope.close = (result) ->
     dialog.close(result)
 
-RegistrationCtrl = ($scope, $cookieStore, $location, SessionService, AlertService) ->
+RegistrationCtrl = ($scope, $cookieStore, $location, SessionService, AlertService, dialog) ->
   $scope.alertService = AlertService
   $scope.registration = SessionService.userRegistration
 
@@ -28,19 +28,23 @@ RegistrationCtrl = ($scope, $cookieStore, $location, SessionService, AlertServic
     if SessionService.signedOut
       $scope.registration.$save().success (response, status, headers, config) ->
         if response.success == true
-          $scope.dismiss()
+          dialog.close(response)
           $location.path('/proposals').search('filter', 'active')
-          AlertService.setInfo 'Thank you for joining Spokenvote!', $scope
+          AlertService.setInfo 'Thank you for joining Spokenvote!', $scope, 'main'
           $scope.updateUserSession()
  #        $cookieStore.put "_spokenvote_session", response   #let Angular set the cookie in the future?
         if response.success == false
-          AlertService.setCtlResult 'Sorry, we were not able to save your registration.', $scope
+          AlertService.setCtlResult 'Sorry, we were not able to save your registration.', $scope, 'modal'
 
   $scope.destroy = ->
     $scope.registration.$destroy()
 
+  $scope.close = (result) ->
+    dialog.close(result)
+
 # Injects
-SessionCtrl.$inject = ['$scope', 'parentScope', '$cookieStore', '$location', 'dialog', 'SessionService', 'AlertService']
+SessionCtrl.$inject = [ '$scope', '$cookieStore', '$location', 'SessionService', 'AlertService', 'dialog' ]
+RegistrationCtrl.$inject = [ '$scope', '$cookieStore', '$location', 'SessionService', 'AlertService', 'dialog' ]
 
 # Register
 App.controller 'SessionCtrl', SessionCtrl

--- a/app/assets/javascripts/angular/controllers/votes_controller.coffee
+++ b/app/assets/javascripts/angular/controllers/votes_controller.coffee
@@ -1,48 +1,61 @@
-SupportCtrl = ($scope, $location, $rootScope, AlertService, Vote) ->
+SupportCtrl = ($scope, $location, $rootScope, AlertService, Vote, dialog) ->
   if $scope.current_user_support == 'related_proposal'
-    AlertService.setCtlResult 'We found support from you on another proposal. If you continue, your previous support will be moved here.', $scope
+    AlertService.setCtlResult 'We found support from you on another proposal. If you continue, your previous support will be moved here.', $scope, 'modal'
 
   $scope.saveSupport = ->
     $scope.newSupport.proposal_id = $scope.clicked_proposal_id
-    $scope.newSupport.user_id = $scope.currentUser.id
     AlertService.clearAlerts()
 
     vote = Vote.save($scope.newSupport
     ,  (response, status, headers, config) ->
       $rootScope.$broadcast 'event:votesChanged'
-      AlertService.setSuccess 'Your vote was created with the comment: \"' + response.comment + '\"', $scope
-      $scope.dismiss()
+      AlertService.setSuccess 'Your vote was created with the comment: \"' + response.comment + '\"', $scope, 'main'
+      dialog.close(response)
     ,  (response, status, headers, config) ->
-      AlertService.setCtlResult 'Sorry, your vote to support this proposal was not counted.', $scope
+      AlertService.setCtlResult 'Sorry, your vote to support this proposal was not counted.', $scope, 'modal'
       AlertService.setJson response.data
     )
 
+  $scope.close = (result) ->
+    dialog.close(result)
+
 ImroveCtrl = ($scope, $location, $rootScope, dialog, AlertService, Proposal) ->
   if $scope.current_user_support == 'related_proposal'
-    AlertService.setCtlResult 'We found support from you on another proposal. If you create a new, improved propsal your previous support will be moved here.', $scope
+    AlertService.setCtlResult 'We found support from you on another proposal. If you create a new, improved propsal your previous support will be moved here.', $scope, 'modal'
 
   $scope.improvedProposal = {}
   $scope.improvedProposal.statement = $scope.proposal.statement
 
   $scope.saveImprovement = ->
-    improvedProposal = {}       #TODO: Refactor to a complex object.
-    improvedProposal.proposal = {}
-    improvedProposal.proposal.votes_attributes = {}
-    improvedProposal.proposal.parent_id = $scope.clicked_proposal_id
-    improvedProposal.user_id = $scope.currentUser.id
-    improvedProposal.proposal.statement = $scope.improvedProposal.statement
-    improvedProposal.proposal.votes_attributes.comment = $scope.improvedProposal.comment
+    improvedProposal =
+      proposal:
+        parent_id: $scope.clicked_proposal_id
+        statement: $scope.improvedProposal.statement
+        votes_attributes:
+          comment: $scope.improvedProposal.comment
+
+#    improvedProposal = {}       #TODO: Refactored above. Delete after Rails vote move is fixed and test passing.
+#    improvedProposal.proposal = {}
+#    improvedProposal.proposal.votes_attributes = {}
+#    improvedProposal.proposal.parent_id = $scope.clicked_proposal_id
+#    improvedProposal.user_id = $scope.currentUser.id
+#    improvedProposal.proposal.statement = $scope.improvedProposal.statement
+#    improvedProposal.proposal.votes_attributes.comment = $scope.improvedProposal.comment
+
     AlertService.clearAlerts()
 
     improvedProposal = Proposal.save(improvedProposal
     ,  (response, status, headers, config) ->
       $rootScope.$broadcast 'event:votesChanged'
       AlertService.setSuccess 'Your improved proposal stating: \"' + response.statement + '\" was created.', $scope, 'main'
-#      dialog.close(response)
+      dialog.close(response)
     ,  (response, status, headers, config) ->
-      AlertService.setCtlResult 'Sorry, your improved proposal was not saved.', $scope
+      AlertService.setCtlResult 'Sorry, your improved proposal was not saved.', $scope, 'modal'
       AlertService.setJson response.data
     )
+
+  $scope.close = (result) ->
+    dialog.close(result)
 
 EditProposalCtrl = ($scope, parentScope, $location, $rootScope, dialog, AlertService, Proposal) ->
   $scope.sessionSettings = parentScope.sessionSettings
@@ -137,7 +150,7 @@ NewProposalCtrl = ($scope, parentScope, $location, $rootScope, dialog, AlertServ
     dialog.close(result)
 
 # Injects
-SupportCtrl.$inject = [ '$scope', '$location', '$rootScope', 'AlertService', 'Vote' ]
+SupportCtrl.$inject = [ '$scope', '$location', '$rootScope', 'AlertService', 'Vote', 'dialog' ]
 ImroveCtrl.$inject = [ '$scope', '$location', '$rootScope', 'dialog', 'AlertService', 'Proposal' ]
 EditProposalCtrl.$inject = [ '$scope', 'parentScope', '$location', '$rootScope', 'dialog', 'AlertService', 'Proposal' ]
 DeleteProposalCtrl.$inject = [ '$scope', '$location', '$rootScope', 'dialog', 'AlertService', 'Proposal', 'parentScope' ]

--- a/app/assets/javascripts/angular/services/session.coffee
+++ b/app/assets/javascripts/angular/services/session.coffee
@@ -73,7 +73,6 @@ AlertService = ($timeout) ->
     @cltActionResult = null
 
 # Interceptors
-# Registers an interceptor for ALL angular ajax http calls
 errorHttpInterceptor = ($q, $location, $rootScope, AlertService) ->
   (promise) ->
     promise.then ((response) ->
@@ -94,7 +93,9 @@ SessionSettings = ->
     searchTerm: null
   openModals:
     signIn: false
+    register: false
     newProposal: false
+    supportProposal: false
     improveProposal: false
     editProposal: false
   searchedHub: {}

--- a/app/assets/javascripts/angular/services/voting.coffee
+++ b/app/assets/javascripts/angular/services/voting.coffee
@@ -1,23 +1,32 @@
-VotingService = ( $dialog, $modal, AlertService, SessionSettings, RelatedVoteInTreeLoader ) ->
+VotingService = ( $dialog, AlertService, SessionSettings, RelatedVoteInTreeLoader ) ->
 
   support: ( scope, clicked_proposal_id ) ->
     scope.clicked_proposal_id = clicked_proposal_id
     scope.current_user_support = null
 
-    RelatedVoteInTreeLoader(clicked_proposal_id).then (relatedSupport) ->
-      if relatedSupport.id?
-        if relatedSupport.proposal.id == clicked_proposal_id
-          scope.current_user_support = 'this_proposal'
+    if !scope.currentUser.id?
+      AlertService.setInfo 'To support proposals you need to sign in.', scope, 'modal'
+      scope.signInModal('VotingService.support', scope, clicked_proposal_id)  #TODO Preparing for Friendly Forwarding, but need some coaching on best practices.
+    else
+      RelatedVoteInTreeLoader(clicked_proposal_id).then (relatedSupport) ->
+        if relatedSupport.id?
+          if relatedSupport.proposal.id == clicked_proposal_id
+            scope.current_user_support = 'this_proposal'
+          else
+            scope.current_user_support = 'related_proposal'
+        if scope.current_user_support == 'this_proposal'
+          AlertService.setInfo 'Good news, it looks as if you have already supported this proposal. Further editing is not allowed at this time.', scope, 'main'
         else
-          scope.current_user_support = 'related_proposal'
-      if scope.current_user_support == 'this_proposal'
-        AlertService.setCtlResult 'Good news, it looks as if you have already supported this proposal. Further editing is not supported at this time.', scope
-      else
-        $modal
-          template: '/assets/proposals/_support_modal.html.haml'
-          show: true
-          backdrop: 'static'
-          scope: scope
+          if SessionSettings.openModals.supportProposal is false
+            scope.opts =
+              resolve:
+                $scope: ->
+                  scope
+            d = $dialog.dialog(scope.opts)
+            SessionSettings.openModals.supportProposal = true
+            d.open('/assets/proposals/_support_modal.html.haml', 'SupportCtrl').then (result) ->
+              SessionSettings.openModals.supportProposal = d.isOpen()
+
 
   improve: ( scope, clicked_proposal_id ) ->
     scope.clicked_proposal_id = clicked_proposal_id
@@ -25,7 +34,7 @@ VotingService = ( $dialog, $modal, AlertService, SessionSettings, RelatedVoteInT
 
     if !scope.currentUser.id?
       scope.signInModal()
-      AlertService.setInfo 'In order to improve proposals, you sign in.', scope, 'modal'
+      AlertService.setInfo 'To improve proposals you need to sign in.', scope, 'modal'
     else
       RelatedVoteInTreeLoader(clicked_proposal_id).then (relatedSupport) ->
         scope.current_user_support = 'related_proposal' if relatedSupport.id?
@@ -79,7 +88,7 @@ VotingService = ( $dialog, $modal, AlertService, SessionSettings, RelatedVoteInT
         SessionSettings.openModals.newProposal = d.isOpen()
 
 # Injects
-VotingService.$inject = [ '$dialog', '$modal', 'AlertService', 'SessionSettings', 'RelatedVoteInTreeLoader'  ]
+VotingService.$inject = [ '$dialog', 'AlertService', 'SessionSettings', 'RelatedVoteInTreeLoader'  ]
 
 # Register
 App.Services.factory 'VotingService', VotingService

--- a/app/assets/stylesheets/partials/_styles.css.scss
+++ b/app/assets/stylesheets/partials/_styles.css.scss
@@ -294,6 +294,11 @@ input.ng-invalid.ng-dirty {
   background-color: #eee;
 }
 
+.modal-footer {
+  .pull-left {
+    text-align: left;
+  }
+}
 .modal-backdrop {
   background-color: #000 !important;
 }

--- a/app/assets/templates/proposals/_improve_proposal_modal.html.haml
+++ b/app/assets/templates/proposals/_improve_proposal_modal.html.haml
@@ -1,11 +1,10 @@
--##improveProposalModal.modal( ng-controller="ImroveCtrl" )
 #improveProposalModal.modal
   .modal-header
-    .pull-right( class='close' data-dismiss='modal' ) &times;
-    %h2 Improve Proposal  {{ alertService.alertDestination }}
+    .pull-right( class='close' ng-click='close()' ) &times;
+    %h2 Improve Proposal
 
     #alertContainer
-      .modalAlert( alert-bar alertmessageclear='alertService.alertClass' )
+      .modalAlert( alert-bar alertmessageclear='alertService.alertClass' ng-show='alertService.alertDestination=="modal"' )
 
   .modal-body
     .proposal_new
@@ -29,4 +28,4 @@
     %fieldset
       .control-group
         .controls
-          %button( ng-click="saveImprovement()" class='btn btn-primary btn-bold' ng-hide='modal.saved' ng-disabled='!improvedProposalForm.$valid' ) Save your Improved proposal <i class="icon-ok"></i>
+          %button( ng-click="saveImprovement()" class='btn btn-primary btn-bold' ng-hide='modal.saved' ng-disabled='!improvedProposalForm.$valid' ) Save Improved proposal

--- a/app/assets/templates/proposals/_support_modal.html.haml
+++ b/app/assets/templates/proposals/_support_modal.html.haml
@@ -1,6 +1,6 @@
-#voteModal.modal( data-width='400px' ng-controller='SupportCtrl' )
+#voteModal.modal
   .modal-header
-    .pull-right(class='close' data-dismiss='modal' aria-hidden='true') &times;
+    .pull-right( class='close'  ng-click='close()' ) &times;
     %h2 Support Proposal
 
     #alertContainer

--- a/app/assets/templates/shared/_registration_modal.html.haml
+++ b/app/assets/templates/shared/_registration_modal.html.haml
@@ -1,10 +1,10 @@
-#registrationModal.modal( data-width='400px' ng-controller='RegistrationCtrl' )
+#registrationModal.modal
   .modal-header
-    .pull-right(class='close' data-dismiss='modal') &times;
+    .pull-right( class='close' ng-click='close()' ) &times;
     %h3 Join SpokenVote
 
     #alertContainer
-      .modalAlert( alert-bar alertmessageclear='alertService.alertClass' )
+      .modalAlert( alert-bar alertmessageclear='alertService.alertClass' ng-show='alertService.alertDestination=="modal"' )
 
   .modal-body
     .login_providers
@@ -37,11 +37,11 @@
           .controls
             %input(id='password_confirmation_field' name='password_confirmation' type='password' class='full-width' ng-model='registration.password_confirmation' required ng-minLength='5' placeholder='Confirm password' )
             .input-below-text( ng-show='registration.password != registration.password_confirmation && registrationForm.password_confirmation.$dirty || registrationForm.$invalid && registrationForm.password_confirmation.$dirty ' ) Almost ...
-            .input-below-text( ng-show='registrationForm.$valid && registration.password == registration.password_confirmation && registrationForm.password_confirmation.$dirty' ) Yes!
+            .input-below-text( ng-show='registrationForm.$valid && registration.password == registration.password_confirmation && registrationForm.password_confirmation.$dirty' ) Match!
         %input( type="submit" class='invisible' )
 
 
   .modal-footer
     .control-group
       .controls
-        %button( ng-click='register()' class='btn btn-primary btn-bold' ng-hide='modal.saved' ng-disabled='!registrationForm.$valid || registration.password != registration.password_confirmation') Join SpokenVote <i class="icon-ok"></i>
+        %button( ng-click='register()' class='btn btn-primary btn-bold' ng-hide='modal.saved' ng-disabled='!registrationForm.$valid || registration.password != registration.password_confirmation') Join SpokenVote

--- a/app/assets/templates/shared/_sign_in_modal.html.haml
+++ b/app/assets/templates/shared/_sign_in_modal.html.haml
@@ -4,7 +4,7 @@
     %h3 Please Sign In
 
     #alertContainer
-      .modalAlert( alert-bar alertmessageclear='alertService.alertClass' ng-show='alertService.alertDestination="modal"' )
+      .modalAlert( alert-bar alertmessageclear='alertService.alertClass' ng-show='alertService.alertDestination=="modal"' )
 
   .modal-body
     .login_providers
@@ -42,5 +42,5 @@
   .modal-footer
     .control-group
       .controls
-        %button( ng-click='signIn()' class='btn btn-primary btn-bold' ng-hide='modal.saved' ng-disabled='!signInForm.$valid' ) Sign In <i class="icon-ok"></i>
-        %button( ng-click='register()' class='btn btn-primary btn-bold' ng-hide='modal.saved' ng-disabled='!signInForm.$valid' ) Join Us <i class="icon-ok"></i>
+        %button( ng-click='registerModal();close()' class='btn btn-warning btn-bold pull-left' ) Need to Sign Up?
+        %button( ng-click='signIn()' class='btn btn-primary btn-bold' ng-disabled='!signInForm.$valid' ) Sign In

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
           .row
             #mainContent
               #alertContainer
-                .pageAlert( alert-bar alertmessageclear='alertService.alertClass' ng-hide='alertService.alertDestination="modal"' )
+                .pageAlert( alert-bar alertmessageclear='alertService.alertClass' ng-hide='alertService.alertDestination=="modal"' )
               %ng-view
 
     -#= render 'shared/footer'


### PR DESCRIPTION
- Alerts are now directed to the modal or the main body
- Converted all modals to newer promise / return technology
- Set up global switches for which modals are open
- Enabled Registration from the Sign In page
- Refactored Improve Proposal object into complex object
- Removed all "user_id"s from Improve and Support server update requests for security reasons.
- Updated look and feel of modal buttons, removed _"check marks"_
