### PR TITLE
Modified hub creation loop in seeds.rb to loop 7 times instead of 10

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ begin
   ]
 
   p 'Creating Hubs'
-  10.times do
+  7.times do
     #location_id = location_ids.keys.sample
     location_id = location_ids.keys[i]
     hubs << Hub.create!({


### PR DESCRIPTION
This is necessary since locations can not be blank and there are only 7 locations in the seed data
