### PR TITLE
 Bug fix for card # 250:  Hub sync on back button

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_controller.coffee
+++ b/app/assets/javascripts/angular/controllers/dashboard_controller.coffee
@@ -23,7 +23,8 @@ DashboardCtrl = ($scope, $route, $location, SessionSettings, CurrentHubLoader, V
     if $scope.hubFilter.hubFilter == null
       $location.search('hub', null)
       SessionSettings.actions.hubFilter = 'All Groups'
-    else if SessionSettings.hub_attributes.id? and !$route.current.params.proposalId? 
+    else if SessionSettings.hub_attributes.id? and SessionSettings.actions.selectHub == true
+      SessionSettings.actions.selectHub = false 
       $location.path('/proposals').search('hub', SessionSettings.hub_attributes.id)
       SessionSettings.actions.hubFilter = SessionSettings.hub_attributes.short_hub
 
@@ -48,6 +49,7 @@ DashboardCtrl = ($scope, $route, $location, SessionSettings, CurrentHubLoader, V
       if not _.isEmpty searchedHub
         SessionSettings.hub_attributes = searchedHub
         SessionSettings.actions.changeHub = false
+        SessionSettings.actions.selectHub = true
         SessionSettings.hub_attributes.id = SessionSettings.hub_attributes.select_id
         $scope.hubFilter.hubFilter = searchedHub 
         searchedHub.full_hub

--- a/app/assets/javascripts/angular/services/session.coffee
+++ b/app/assets/javascripts/angular/services/session.coffee
@@ -94,6 +94,7 @@ SessionSettings = ->
     changeHub: false
     newProposalHub: null
     searchTerm: null
+    selectHub: false
   openModals:
     signIn: false
     register: false


### PR DESCRIPTION
Adds check for change of hub during creation of a new topic.  It will now update the hub selection text box when this change is detected.  Also insures all proposals for the hub will not be reloaded if a proposal detail page is being requested via the proposalId parameter.  Only the proposal detail page should be loaded.
