### PR TITLE
dedicated-SEO-landing-pages

### DIFF
--- a/app/assets/javascripts/angular/spokenvote.coffee
+++ b/app/assets/javascripts/angular/spokenvote.coffee
@@ -7,7 +7,7 @@ appConfig = ['$routeProvider', '$locationProvider', '$httpProvider', '$modalProv
 
   $routeProvider
     .when( '/'
-      title: 'Online Group Consensus Tool'
+      title: 'Group Consensus Tool'
       callToAction: 'Your Group Decisions'
       templateUrl: 'pages/landing.html'
       resolve:
@@ -26,13 +26,20 @@ appConfig = ['$routeProvider', '$locationProvider', '$httpProvider', '$modalProv
         pageTitle: [ '$rootScope', '$route', ($rootScope, $route) ->
           $rootScope.page.setTitle $route.current.params.filter, $route.current.title
         ]
+        setCallToAction: [ '$rootScope', '$route', ($rootScope, $route) ->
+          $rootScope.page.setCallToAction $route.current.callToAction
+        ]
     )
     .when( '/group-consensus-tool'
       title: 'Group Consensus Tool'
       templateUrl: 'pages/landing.html'
+      callToAction: 'Group Consensus Tool'
       resolve:
         pageTitle: [ '$rootScope', '$route', ($rootScope, $route) ->
           $rootScope.page.setTitle $route.current.params.filter, $route.current.title
+        ]
+        setCallToAction: [ '$rootScope', '$route', ($rootScope, $route) ->
+          $rootScope.page.setCallToAction $route.current.callToAction
         ]
     )
     .when( '/proposals'

--- a/app/assets/templates/pages/landing.html.slim
+++ b/app/assets/templates/pages/landing.html.slim
@@ -16,7 +16,7 @@ section( itemscope itemtype='http://schema.org/Organization' )
     -#.tag_line Voting redefined.
     -#.call_to_action Decisions that affect you.
     /.call_to_action Your Group Decisions.
-    .call_to_action Your Group Decisions.
+    .call_to_action {{ page.callToAction }}.
 
 
     .instructions

--- a/test/spec/application/routes_spec.coffee
+++ b/test/spec/application/routes_spec.coffee
@@ -1,39 +1,52 @@
 describe 'Routes Tests', ->
   $route = undefined
   $rootScope = undefined
-  $controller = undefined
   $httpBackend = undefined
   $location = undefined
-  SessionSettings = undefined
+#  $controller = undefined
+#  SessionSettings = undefined
 
   beforeEach module 'spokenvote', 'spokenvoteMocks'
 
-  describe 'Router Testing', ->
-    beforeEach inject (_$route_, _$rootScope_, _$controller_, _$httpBackend_, _$location_, _SessionSettings_) ->
+  describe 'Injecting $ route into Router Testing', ->
+    beforeEach inject (_$route_, _$rootScope_, _$httpBackend_, _$location_) ->
       $route = _$route_
       $rootScope = _$rootScope_
       $httpBackend = _$httpBackend_
       $location = _$location_
-      $controller = _$controller_
-      SessionSettings = _SessionSettings_
+#      $controller = _$controller_
+#      SessionSettings = _SessionSettings_
 
-    it 'should map routes to templates, callToAction, controllers, rootscope page titles, and rootscope callToAction', ->
-      expect $route.routes['/'].controller
-        .toBeUndefined()
-      expect $route.routes["/"].templateUrl
-        .toEqual 'pages/landing.html'
-      expect $route.routes['/landing'].controller
-      .toBeUndefined()
-
-#      # otherwise redirect to
-#      expect($route.routes[null].redirectTo).toEqual "/phones"
+    it 'routes should start out undefined', ->
 
       expect $route.current
         .toBeUndefined()
 
+    it 'root path should map route to correct template, callToAction, controller, rootscope page title and rootscope callToAction', ->
+
       $httpBackend.expectGET 'pages/landing.html'
         .respond 200
       $location.path '/'
+      $rootScope.$digest()
+
+      expect $route.current.templateUrl
+        .toBe 'pages/landing.html'
+      expect $route.current.callToAction
+        .toBe 'Your Group Decisions'
+      expect $route.current.controller
+        .toBeUndefined()
+      expect $route.current.title
+        .toEqual 'Group Consensus Tool'
+      expect $rootScope.page.title
+        .toEqual 'Group Consensus Tool | Spokenvote'
+      expect $rootScope.page.callToAction
+        .toEqual 'Your Group Decisions'
+
+    it '/landing path should map route to correct template, callToAction, controller, rootscope page title and rootscope callToAction', ->
+
+      $httpBackend.expectGET 'pages/landing.html'
+        .respond 200
+      $location.path '/landing'
       $rootScope.$digest()
 
       expect $route.current.templateUrl
@@ -49,11 +62,35 @@ describe 'Routes Tests', ->
       expect $rootScope.page.callToAction
         .toEqual 'Your Group Decisions'
 
-      $location.path '/otherwise'
+    it '/group-consensus-tool path should map route to correct template, callToAction, controller, rootscope page title and rootscope callToAction', ->
+
+      $httpBackend.expectGET 'pages/landing.html'
+        .respond 200
+      $location.path '/group-consensus-tool'
+      $rootScope.$digest()
+
+      expect $route.current.templateUrl
+        .toBe 'pages/landing.html'
+      expect $route.current.callToAction
+        .toBe 'Group Consensus Tool'
+      expect $route.current.controller
+        .toBeUndefined()
+      expect $route.current.title
+        .toEqual 'Group Consensus Tool'
+      expect $rootScope.page.title
+        .toEqual 'Group Consensus Tool | Spokenvote'
+      expect $rootScope.page.callToAction
+        .toEqual 'Group Consensus Tool'
+
+    it 'bad urls should map route to rootscope page title, but undefined callToAction, template and controller', ->
+
+      $location.path '/bad-url'
       $rootScope.$digest()
 
       expect $location.path()
-        .toBe '/otherwise'
+        .toBe '/bad-url'
+      expect $route.current.callToAction
+        .toBeUndefined()
       expect $route.current.templateUrl
         .toBeUndefined()
       expect $route.current.controller


### PR DESCRIPTION
- Created tests for landing pages
- Added CallToAction $route property
- Added setCallToAction fuction to set $rootScope value
- Wired landing pages to read callToAction values dynamically
